### PR TITLE
Mark `subscript(bitAt:)` public

### DIFF
--- a/sources/Words and Bits.swift
+++ b/sources/Words and Bits.swift
@@ -21,7 +21,7 @@ extension Array where Element == UInt {
 }
 
 extension BigUInt {
-    subscript(bitAt index: Int) -> Bool {
+    public subscript(bitAt index: Int) -> Bool {
         get {
             precondition(index >= 0)
             let (i, j) = index.quotientAndRemainder(dividingBy: Word.bitWidth)


### PR DESCRIPTION
This patch makes the `bitAt:` subscript on `BigUInt` public instead of internal.