### PR TITLE
More Liberal Access Permissions for BigUInt

### DIFF
--- a/sources/BigUInt.swift
+++ b/sources/BigUInt.swift
@@ -27,8 +27,8 @@ public struct BigUInt: UnsignedInteger {
         case array
     }
 
-    internal private(set) var kind: Kind // Internal for testing only
-    internal private(set) var storage: [Word] // Internal for testing only; stored separately to prevent COW copies
+    internal fileprivate (set) var kind: Kind // Internal for testing only
+    internal fileprivate (set) var storage: [Word] // Internal for testing only; stored separately to prevent COW copies
 
     /// Initializes a new BigUInt with value 0.
     public init() {


### PR DESCRIPTION
`kind` and `storage` are now `fileprivate` (were `private`). This allows the code to compile under Swift 3.2.