### PR TITLE
Fixed small documentation error in signum()

### DIFF
--- a/sources/BigUInt.swift
+++ b/sources/BigUInt.swift
@@ -77,7 +77,7 @@ extension BigUInt {
         }
     }
 
-    /// Returns `-1` if this value is negative and `1` if it’s positive; otherwise, `0`.
+    /// Returns `1` if this value is, positive; otherwise, `0`.
     ///
     /// - Returns: The sign of this number, expressed as an integer of the same type.
     public func signum() -> BigUInt {


### PR DESCRIPTION
While going through your code I found a small documentation error:

The documentation for `signum()` in `BigUInt` said:

```
/// Returns `-1` if this value is negative and `1` if it’s positive; otherwise, `0`.
///
/// - Returns: The sign of this number, expressed as an integer of the same type.
public func signum() -> BigUInt {
    return isZero ? 0 : 1
}
```

It now says:

```
/// Returns `1` if this value is, positive; otherwise, `0`.
///
/// - Returns: The sign of this number, expressed as an integer of the same type.
public func signum() -> BigUInt {
    return isZero ? 0 : 1
}
```