### PR TITLE
Fixed deprecation warning for `.characters` in String Conversion

### DIFF
--- a/sources/String Conversion.swift
+++ b/sources/String Conversion.swift
@@ -94,11 +94,11 @@ extension BigInt {
     init?(_ text: Substring, radix: Int = 10) {
         var text = text
         var sign: Sign = .plus
-        if text.characters.first == "-" {
+        if text.first == "-" {
             sign = .minus
             text = text.dropFirst()
         }
-        else if text.characters.first == "+" {
+        else if text.first == "+" {
             text = text.dropFirst()
         }
         guard let magnitude = BigUInt(text, radix: radix) else { return nil }
@@ -143,7 +143,7 @@ extension String {
         self = ""
         var first = true
         for part in parts.reversed() {
-            let zeroes = charsPerWord - part.characters.count
+            let zeroes = charsPerWord - part.count
             assert(zeroes >= 0)
             if !first && zeroes > 0 {
                 // Insert leading zeroes for mid-Words


### PR DESCRIPTION
While building the module, the Swift warns about the deprecation of `characters` and advises to use the `String` directly. By removing the call to `characters`, this is what I have done.