### PR TITLE
Updated Readme for BigInt 4.0, removed paragraph about "Full-width mu…

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ BigInt can be used, distributed and modified under [the MIT license][license].
 
 ## <a name="integration">Requirements and Integration</a>
 
-BigInt 3.0.0 requires Swift 4. (The last version with support for Swift 3.x was BigInt 2.1.0.
+BigInt 4.0.0 requires Swift 4.2 (The last version with support for Swift 3.x was BigInt 2.1.0.
 The last version with support for Swift 2 was BigInt 1.3.0.)
 
 | Swift Version | last BigInt Version|
@@ -144,17 +144,6 @@ automatically extends the array on out-of-bound `set`s. This makes memory manage
 
 [`BigInt`][BigInt] is just a tiny wrapper around a `BigUInt` [absolute value][abs] and a
 [sign bit][negative], both of which are accessible as public read-write properties.
-
-### <a name="fullwidth">Full-width multiplication and division primitives</a>
-
-I haven't found (64,64)->128 multiplication or (128,64)->64 division operations
-in Swift, so [the module has generic implementations for them][fullmuldiv] in terms of the standard
-single-width `*` and `/` operators. I suspect there are LLVM intrinsics for full-width
-arithmetics that are probably accessible somehow, though. ([Let me know][twitter] if you know how!)
-
-This sounds slow, but 64-bit digits are
-still considerably faster than 32-bit, even though the latter can use direct 64-bit arithmetic to
-implement these primitives.
 
 ### <a name="generics">Why is there no generic `BigInt<Digit>` type?</a>
 


### PR DESCRIPTION
…ltiplication and division primitives", which explained implementation details of BigInt 2.0.