### PR TITLE
Workaround for Compiler Crash on Swift Trunk and S4TF

### DIFF
--- a/Sources/Division.swift
+++ b/Sources/Division.swift
@@ -8,7 +8,7 @@
 
 //MARK: Full-width multiplication and division
 
-// where Magnitude == Self 
+// TODO: Return to `where Magnitude == Self` when SR-13491 is resolved
 extension FixedWidthInteger {
     private var halfShift: Self {
         return Self(Self.bitWidth / 2)

--- a/Sources/Division.swift
+++ b/Sources/Division.swift
@@ -8,7 +8,8 @@
 
 //MARK: Full-width multiplication and division
 
-extension FixedWidthInteger where Magnitude == Self {
+// where Magnitude == Self 
+extension FixedWidthInteger {
     private var halfShift: Self {
         return Self(Self.bitWidth / 2)
 
@@ -91,13 +92,13 @@ extension FixedWidthInteger where Magnitude == Self {
         let w = Self(Self.bitWidth) - z
         let vn = self << z
 
-        let un32 = (z == 0 ? dividend.high : (dividend.high &<< z) | (dividend.low &>> w)) // No bits are lost
+        let un32 = (z == 0 ? dividend.high : (dividend.high &<< z) | ((dividend.low as! Self) &>> w)) // No bits are lost
         let un10 = dividend.low &<< z
         let (un1, un0) = un10.split
 
         // Divide `(un32,un10)` by `vn`, splitting the full 4/2 division into two 3/2 ones.
-        let (q1, un21) = quotientAndRemainder(dividing: (un32, un1), by: vn)
-        let (q0, rn) = quotientAndRemainder(dividing: (un21, un0), by: vn)
+        let (q1, un21) = quotientAndRemainder(dividing: (un32, (un1 as! Self)), by: vn)
+        let (q0, rn) = quotientAndRemainder(dividing: (un21, (un0 as! Self)), by: vn)
 
         // Undo normalization of the remainder and combine the two halves of the quotient.
         let mod = rn >> z
@@ -120,7 +121,7 @@ extension FixedWidthInteger where Magnitude == Self {
             r = s
         }
         else {
-            (q, r) = y.0.fastDividingFullWidth((x.0, x.1))
+            (q, r) = y.0.fastDividingFullWidth((x.0, (x.1 as! Magnitude)))
         }
         // Now refine q by considering x.2 and y.1.
         // Note that since y is normalized, q * y - x is between 0 and 2.
@@ -130,7 +131,7 @@ extension FixedWidthInteger where Magnitude == Self {
         let (r1, ro) = r.addingReportingOverflow(y.0)
         if ro { return q - 1 }
 
-        let (pl1, so) = pl.subtractingReportingOverflow(y.1)
+        let (pl1, so) = pl.subtractingReportingOverflow((y.1 as! Magnitude))
         let ph1 = (so ? ph - 1 : ph)
 
         if ph1 < r1 || (ph1 == r1 && pl1 <= x.2) { return q - 1 }

--- a/Tests/BigIntTests/WordTests.swift
+++ b/Tests/BigIntTests/WordTests.swift
@@ -9,7 +9,7 @@
 import XCTest
 @testable import BigInt
 
-// where Word.Magnitude == Word 
+// TODO: Return to `where Word.Magnitude == Word` when SR-13491 is resolved
 struct TestDivision<Word: FixedWidthInteger> {
     static func testDivision(_ u: (high: Word, low: Word.Magnitude), _ v: Word) {
         let (div, mod) = v.fastDividingFullWidth(u)

--- a/Tests/BigIntTests/WordTests.swift
+++ b/Tests/BigIntTests/WordTests.swift
@@ -9,11 +9,12 @@
 import XCTest
 @testable import BigInt
 
-struct TestDivision<Word: FixedWidthInteger> where Word.Magnitude == Word {
+// where Word.Magnitude == Word 
+struct TestDivision<Word: FixedWidthInteger> {
     static func testDivision(_ u: (high: Word, low: Word.Magnitude), _ v: Word) {
         let (div, mod) = v.fastDividingFullWidth(u)
         var (ph, pl) = div.multipliedFullWidth(by: v)
-        let (s, o) = pl.addingReportingOverflow(mod)
+        let (s, o) = pl.addingReportingOverflow((mod as! Word.Magnitude))
         pl = s
         if o { ph += Word(1) }
 


### PR DESCRIPTION
Thanks to Slava's guidance in [SR-13491](https://bugs.swift.org/browse/SR-13491), I was able to create a simple workaround for #75. This should have equivalent behavior because it is simple type casting rather than using the `where` clause on type `Magnitude`. I successfully tested `swift build` and `swift test` in the following situations:

- Ubuntu 18.04, Swift for Tensorflow 0.12rc2:
```
$ which swift
/home/xander/swift-tensorflow-RELEASE-0.12-cuda10.2-cudnn7-ubuntu18.04/usr/bin/swift
$ swift --version
Swift version 5.3-dev (LLVM 69d8678431d3eee, Swift e1aef96b7fea59b)
Target: x86_64-unknown-linux-gnu
```
- macOS 10.15.7, Swift 5.3:
```
$ which swift
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift
$ swift --version
Apple Swift version 5.3 (swiftlang-1200.0.29.2 clang-1200.0.30.1)
Target: x86_64-apple-darwin19.6.0
```
- Ubuntu 18.04, Swift dev trunk 2020-11-05:
```
$ which swift
/home/xander/swift-DEVELOPMENT-SNAPSHOT-2020-11-05-a-ubuntu18.04/usr/bin/swift
$ swift --version
Swift version 5.3-dev (LLVM ea8eac6ba760b92, Swift e8151ee2b27776f)
Target: x86_64-unknown-linux-gnu
```
- macOS 10.15.7, Swift for Tensorflow 0.11:
```
$ which swift
/Library/Developer/Toolchains/swift-tensorflow-RELEASE-0.11.xctoolchain/usr/bin/swift
$ swift --version
Swift version 5.3-dev (LLVM db8896f3f345af2, Swift 61684f62a6132c0)
Target: x86_64-apple-darwin19.6.0
```
All of them build successfully and all tests pass.

This fixes the build on Swift for Tensorflow. If the project could accept this workaround until SR-13491 is resolved it would be hugely beneficial to upstream projects like [googleapis/google-auth-library-swift](https://github.com/googleapis/google-auth-library-swift) for use in Swift for Tensorflow projects.