### PR TITLE
Decimal and Foundation

### DIFF
--- a/Sources/Comparable.swift
+++ b/Sources/Comparable.swift
@@ -6,9 +6,19 @@
 //  Copyright © 2016-2017 Károly Lőrentey.
 //
 
+#if canImport(Foundation)
 import Foundation
+#endif
 
 extension BigUInt: Comparable {
+    #if !canImport(Foundation)
+    public enum ComparisonResult: Sendable, Comparable, Hashable {
+        case orderedDescending
+        case orderedSame
+        case orderedAscending
+    }
+    #endif
+
     //MARK: Comparison
     
     /// Compare `a` to `b` and return an `NSComparisonResult` indicating their order.

--- a/Sources/Data Conversion.swift
+++ b/Sources/Data Conversion.swift
@@ -6,7 +6,9 @@
 //  Copyright © 2016-2017 Károly Lőrentey.
 //
 
+#if canImport(Foundation)
 import Foundation
+#endif
 
 extension BigUInt {
     //MARK: NSData Conversion
@@ -43,7 +45,33 @@ extension BigUInt {
         assert(c == 0 && word == 0 && index == -1)
     }
 
+    /// Return a `UnsafeRawBufferPointer` buffer that contains the base-256 representation of this integer, in network (big-endian) byte order.
+    public func serializeToBuffer() -> UnsafeRawBufferPointer {
+        // This assumes Digit is binary.
+        precondition(Word.bitWidth % 8 == 0)
 
+        let byteCount = (self.bitWidth + 7) / 8
+
+        let buffer = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: byteCount)
+
+        guard byteCount > 0 else { return UnsafeRawBufferPointer(start: buffer.baseAddress, count: 0) }
+
+        var i = byteCount - 1
+        for var word in self.words {
+            for _ in 0 ..< Word.bitWidth / 8 {
+                buffer[i] = UInt8(word & 0xFF)
+                word >>= 8
+                if i == 0 {
+                    assert(word == 0)
+                    break
+                }
+                i -= 1
+            }
+        }
+        return UnsafeRawBufferPointer(start: buffer.baseAddress, count: byteCount)
+    }
+
+    #if canImport(Foundation)
     /// Initializes an integer from the bits stored inside a piece of `Data`.
     /// The data is assumed to be in network (big-endian) byte order.
     public init(_ data: Data) {
@@ -82,31 +110,15 @@ extension BigUInt {
 
     /// Return a `Data` value that contains the base-256 representation of this integer, in network (big-endian) byte order.
     public func serialize() -> Data {
-        // This assumes Digit is binary.
-        precondition(Word.bitWidth % 8 == 0)
+        let buffer = serializeToBuffer()
+        defer { buffer.deallocate() }
+        guard
+            let pointer = buffer.baseAddress.map(UnsafeMutableRawPointer.init(mutating:))
+        else { return Data() }
 
-        let byteCount = (self.bitWidth + 7) / 8
-
-        guard byteCount > 0 else { return Data() }
-
-        var data = Data(count: byteCount)
-        data.withUnsafeMutableBytes { buffPtr in
-            let p = buffPtr.bindMemory(to: UInt8.self)
-            var i = byteCount - 1
-            for var word in self.words {
-                for _ in 0 ..< Word.bitWidth / 8 {
-                    p[i] = UInt8(word & 0xFF)
-                    word >>= 8
-                    if i == 0 {
-                        assert(word == 0)
-                        break
-                    }
-                    i -= 1
-                }
-            }
-        }
-        return data
+        return Data(bytes: pointer, count: buffer.count)
     }
+    #endif
 }
 
 extension BigInt {
@@ -133,7 +145,29 @@ extension BigInt {
 
         self.magnitude = BigUInt(UnsafeRawBufferPointer(rebasing: buffer.dropFirst(1)))
     }
-    
+
+    /// Return a `Data` value that contains the base-256 representation of this integer, in network (big-endian) byte order and a prepended byte to indicate the sign (0 for positive, 1 for negative)
+    public func serializeToBuffer() -> UnsafeRawBufferPointer {
+        // Create a data object for the magnitude portion of the BigInt
+        let magnitudeBuffer = self.magnitude.serializeToBuffer()
+
+        // Similar to BigUInt, a value of 0 should return an empty buffer
+        guard magnitudeBuffer.count > 0 else { return magnitudeBuffer }
+
+        // Create a new buffer for the signed BigInt value
+        let newBuffer = UnsafeMutableRawBufferPointer.allocate(byteCount: magnitudeBuffer.count + 1, alignment: 8)
+        let magnitudeSection = UnsafeMutableRawBufferPointer(rebasing: newBuffer[1...])
+        magnitudeSection.copyBytes(from: magnitudeBuffer)
+        magnitudeBuffer.deallocate()
+
+        // The first byte should be 0 for a positive value, or 1 for a negative value
+        // i.e., the sign bit is the LSB
+        newBuffer[0] = self.sign == .plus ? 0 : 1
+
+        return UnsafeRawBufferPointer(start: newBuffer.baseAddress, count: newBuffer.count)
+    }
+
+    #if canImport(Foundation)
     /// Initializes an integer from the bits stored inside a piece of `Data`.
     /// The data is assumed to be in network (big-endian) byte order with a first
     /// byte to represent the sign (0 for positive, 1 for negative)
@@ -160,20 +194,13 @@ extension BigInt {
     
     /// Return a `Data` value that contains the base-256 representation of this integer, in network (big-endian) byte order and a prepended byte to indicate the sign (0 for positive, 1 for negative)
     public func serialize() -> Data {
-        // Create a data object for the magnitude portion of the BigInt
-        let magnitudeData = self.magnitude.serialize()
-        
-        // Similar to BigUInt, a value of 0 should return an initialized, empty Data struct
-        guard magnitudeData.count > 0 else { return magnitudeData }
-        
-        // Create a new Data struct for the signed BigInt value
-        var data = Data(capacity: magnitudeData.count + 1)
-        
-        // The first byte should be 0 for a positive value, or 1 for a negative value
-        // i.e., the sign bit is the LSB
-        data.append(self.sign == .plus ? 0 : 1)
-        
-        data.append(magnitudeData)
-        return data
+        let buffer = serializeToBuffer()
+        defer { buffer.deallocate() }
+        guard
+            let pointer = buffer.baseAddress.map(UnsafeMutableRawPointer.init(mutating:))
+        else { return Data() }
+
+        return Data(bytes: pointer, count: buffer.count)
     }
+    #endif
 }

--- a/Sources/Floating Point Conversion.swift
+++ b/Sources/Floating Point Conversion.swift
@@ -67,14 +67,9 @@ extension BigUInt {
 
 extension BigInt {
     public init?<T: BinaryFloatingPoint>(exactly source: T) {
-        switch source.sign{
-        case .plus:
-            guard let magnitude = BigUInt(exactly: source) else { return nil }
-            self = BigInt(sign: .plus, magnitude: magnitude)
-        case .minus:
-            guard let magnitude = BigUInt(exactly: -source) else { return nil }
-            self = BigInt(sign: .minus, magnitude: magnitude)
-        }
+        guard let magnitude = BigUInt(exactly: source.magnitude) else { return nil }
+        let sign = BigInt.Sign(source.sign)
+        self.init(sign: sign, magnitude: magnitude)
     }
 
     public init<T: BinaryFloatingPoint>(_ source: T) {

--- a/Sources/Floating Point Conversion.swift
+++ b/Sources/Floating Point Conversion.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2016-2017 Károly Lőrentey.
 //
 
+#if canImport(Foundation)
+import Foundation
+#endif
+
 extension BigUInt {
     public init?<T: BinaryFloatingPoint>(exactly source: T) {
         guard source.isFinite else { return nil }
@@ -22,6 +26,43 @@ extension BigUInt {
     public init<T: BinaryFloatingPoint>(_ source: T) {
         self.init(exactly: source.rounded(.towardZero))!
     }
+
+    #if canImport(Foundation)
+    public init?(exactly source: Decimal) {
+        guard source.isFinite else { return nil }
+        guard !source.isZero else { self = 0; return }
+        guard source.sign == .plus else { return nil }
+        assert(source.floatingPointClass == .positiveNormal)
+        guard source.exponent >= 0 else { return nil }
+        let intMaxD = Decimal(UInt.max)
+        let intMaxB = BigUInt(UInt.max)
+        var start = BigUInt()
+        var value = source
+        while value >= intMaxD {
+            start += intMaxB
+            value -= intMaxD
+        }
+        start += BigUInt((value as NSNumber).uintValue)
+        self = start
+    }
+
+    public init?(truncating source: Decimal) {
+        guard source.isFinite else { return nil }
+        guard !source.isZero else { self = 0; return }
+        guard source.sign == .plus else { return nil }
+        assert(source.floatingPointClass == .positiveNormal)
+        let intMaxD = Decimal(UInt.max)
+        let intMaxB = BigUInt(UInt.max)
+        var start = BigUInt()
+        var value = source
+        while value >= intMaxD {
+            start += intMaxB
+            value -= intMaxD
+        }
+        start += BigUInt((value as NSNumber).uintValue)
+        self = start
+    }
+    #endif
 }
 
 extension BigInt {
@@ -39,6 +80,20 @@ extension BigInt {
     public init<T: BinaryFloatingPoint>(_ source: T) {
         self.init(exactly: source.rounded(.towardZero))!
     }
+
+    #if canImport(Foundation)
+    public init?(exactly source: Decimal) {
+        guard let magnitude = BigUInt(exactly: source.magnitude) else { return nil }
+        let sign = BigInt.Sign(source.sign)
+        self.init(sign: sign, magnitude: magnitude)
+    }
+
+    public init?(truncating source: Decimal) {
+        guard let magnitude = BigUInt(truncating: source.magnitude) else { return nil }
+        let sign = BigInt.Sign(source.sign)
+        self.init(sign: sign, magnitude: magnitude)
+    }
+    #endif
 }
 
 extension BinaryFloatingPoint where RawExponent: FixedWidthInteger, RawSignificand: FixedWidthInteger {
@@ -69,5 +124,16 @@ extension BinaryFloatingPoint where RawExponent: FixedWidthInteger, RawSignifica
 
     public init(_ value: BigUInt) {
         self.init(BigInt(sign: .plus, magnitude: value))
+    }
+}
+
+extension BigInt.Sign {
+    public init(_ sign: FloatingPointSign) {
+        switch sign {
+        case .plus:
+            self = .plus
+        case .minus:
+            self = .minus
+        }
     }
 }

--- a/Sources/String Conversion.swift
+++ b/Sources/String Conversion.swift
@@ -221,12 +221,27 @@ extension BigInt: CustomStringConvertible {
     }
 }
 
+extension BigUInt: CustomDebugStringConvertible {
+    /// Return the decimal representation of this integer.
+    public var debugDescription: String {
+        let text = String(self)
+        return text + " (\(self.bitWidth) bits)"
+    }
+}
+
+extension BigInt: CustomDebugStringConvertible {
+    /// Return the decimal representation of this integer.
+    public var debugDescription: String {
+        let text = String(self)
+        return text + " (\(self.magnitude.bitWidth) bits)"
+    }
+}
+
 extension BigUInt: CustomPlaygroundDisplayConvertible {
 
     /// Return the playground quick look representation of this integer.
     public var playgroundDescription: Any {
-        let text = String(self)
-        return text + " (\(self.bitWidth) bits)"
+        debugDescription
     }
 }
 
@@ -234,7 +249,6 @@ extension BigInt: CustomPlaygroundDisplayConvertible {
 
     /// Return the playground quick look representation of this integer.
     public var playgroundDescription: Any {
-        let text = String(self)
-        return text + " (\(self.magnitude.bitWidth) bits)"
+        debugDescription
     }
 }

--- a/Tests/BigIntTests/BigIntTests.swift
+++ b/Tests/BigIntTests/BigIntTests.swift
@@ -8,6 +8,7 @@
 
 import XCTest
 @testable import BigInt
+import Foundation
 
 class BigIntTests: XCTestCase {
     typealias Word = BigInt.Word
@@ -90,7 +91,43 @@ class BigIntTests: XCTestCase {
         XCTAssertEqual(BigInt(truncatingIfNeeded: -42), -42)
         XCTAssertEqual(BigInt(truncatingIfNeeded: 42), 42)
     }
-    
+
+    func testInit_Decimal() throws {
+        XCTAssertEqual(BigInt(exactly: Decimal(0)), 0)
+        XCTAssertEqual(BigInt(exactly: Decimal(Double.nan)), nil)
+        XCTAssertEqual(BigInt(exactly: Decimal(10)), 10)
+        XCTAssertEqual(BigInt(exactly: Decimal(1000)), 1000)
+        XCTAssertEqual(BigInt(exactly: Decimal(1000.1)), nil)
+        XCTAssertEqual(BigInt(exactly: Decimal(1000.9)), nil)
+        XCTAssertEqual(BigInt(exactly: Decimal(1001.5)), nil)
+        XCTAssertEqual(BigInt(exactly: Decimal(UInt.max) + 5), "18446744073709551620")
+        XCTAssertEqual(BigInt(exactly: (Decimal(UInt.max) + 5.5)), nil)
+        XCTAssertEqual(BigInt(truncating: Decimal(0)), 0)
+        XCTAssertEqual(BigInt(truncating: Decimal(Double.nan)), nil)
+        XCTAssertEqual(BigInt(truncating: Decimal(10)), 10)
+        XCTAssertEqual(BigInt(truncating: Decimal(1000)), 1000)
+        XCTAssertEqual(BigInt(truncating: Decimal(1000.1)), 1000)
+        XCTAssertEqual(BigInt(truncating: Decimal(1000.9)), 1000)
+        XCTAssertEqual(BigInt(truncating: Decimal(1001.5)), 1001)
+        XCTAssertEqual(BigInt(truncating: Decimal(UInt.max) + 5), "18446744073709551620")
+        XCTAssertEqual(BigInt(truncating: (Decimal(UInt.max) + 5.5)), "18446744073709551620")
+
+        XCTAssertEqual(BigInt(exactly: -Decimal(10)), -10)
+        XCTAssertEqual(BigInt(exactly: -Decimal(1000)), -1000)
+        XCTAssertEqual(BigInt(exactly: -Decimal(1000.1)), nil)
+        XCTAssertEqual(BigInt(exactly: -Decimal(1000.9)), nil)
+        XCTAssertEqual(BigInt(exactly: -Decimal(1001.5)), nil)
+        XCTAssertEqual(BigInt(exactly: -(Decimal(UInt.max) + 5)), "-18446744073709551620")
+        XCTAssertEqual(BigInt(exactly: -(Decimal(UInt.max) + 5.5)), nil)
+        XCTAssertEqual(BigInt(truncating: -Decimal(10)), -10)
+        XCTAssertEqual(BigInt(truncating: -Decimal(1000)), -1000)
+        XCTAssertEqual(BigInt(truncating: -Decimal(1000.1)), -1000)
+        XCTAssertEqual(BigInt(truncating: -Decimal(1000.9)), -1000)
+        XCTAssertEqual(BigInt(truncating: -Decimal(1001.5)), -1001)
+        XCTAssertEqual(BigInt(truncating: -(Decimal(UInt.max) + 5)), "-18446744073709551620")
+        XCTAssertEqual(BigInt(truncating: -(Decimal(UInt.max) + 5.5)), "-18446744073709551620")
+    }
+
     func testInit_Buffer() {
         func test(_ b: BigInt, _ d: Array<UInt8>, file: StaticString = #file, line: UInt = #line) {
             d.withUnsafeBytes { buffer in

--- a/Tests/BigIntTests/BigUIntTests.swift
+++ b/Tests/BigIntTests/BigUIntTests.swift
@@ -156,7 +156,43 @@ class BigUIntTests: XCTestCase {
         check(BigUInt(Double(sign: .plus, exponent: 2 * Word.bitWidth, significand: 1.0)),
               nil, [0, 0, 1])
     }
-    
+
+    func testInit_Decimal() throws {
+        XCTAssertEqual(BigUInt(exactly: Decimal(0)), 0)
+        XCTAssertEqual(BigUInt(exactly: Decimal(Double.nan)), nil)
+        XCTAssertEqual(BigUInt(exactly: Decimal(10)), 10)
+        XCTAssertEqual(BigUInt(exactly: Decimal(1000)), 1000)
+        XCTAssertEqual(BigUInt(exactly: Decimal(1000.1)), nil)
+        XCTAssertEqual(BigUInt(exactly: Decimal(1000.9)), nil)
+        XCTAssertEqual(BigUInt(exactly: Decimal(1001.5)), nil)
+        XCTAssertEqual(BigUInt(exactly: Decimal(UInt.max) + 5), "18446744073709551620")
+        XCTAssertEqual(BigUInt(exactly: (Decimal(UInt.max) + 5.5)), nil)
+        XCTAssertEqual(BigUInt(truncating: Decimal(0)), 0)
+        XCTAssertEqual(BigUInt(truncating: Decimal(Double.nan)), nil)
+        XCTAssertEqual(BigUInt(truncating: Decimal(10)), 10)
+        XCTAssertEqual(BigUInt(truncating: Decimal(1000)), 1000)
+        XCTAssertEqual(BigUInt(truncating: Decimal(1000.1)), 1000)
+        XCTAssertEqual(BigUInt(truncating: Decimal(1000.9)), 1000)
+        XCTAssertEqual(BigUInt(truncating: Decimal(1001.5)), 1001)
+        XCTAssertEqual(BigUInt(truncating: Decimal(UInt.max) + 5), "18446744073709551620")
+        XCTAssertEqual(BigUInt(truncating: (Decimal(UInt.max) + 5.5)), "18446744073709551620")
+
+        XCTAssertEqual(BigUInt(exactly: -Decimal(10)), nil)
+        XCTAssertEqual(BigUInt(exactly: -Decimal(1000)), nil)
+        XCTAssertEqual(BigUInt(exactly: -Decimal(1000.1)), nil)
+        XCTAssertEqual(BigUInt(exactly: -Decimal(1000.9)), nil)
+        XCTAssertEqual(BigUInt(exactly: -Decimal(1001.5)), nil)
+        XCTAssertEqual(BigUInt(exactly: -Decimal(UInt.max) + 5), nil)
+        XCTAssertEqual(BigUInt(exactly: -(Decimal(UInt.max) + 5.5)), nil)
+        XCTAssertEqual(BigUInt(truncating: -Decimal(10)), nil)
+        XCTAssertEqual(BigUInt(truncating: -Decimal(1000)), nil)
+        XCTAssertEqual(BigUInt(truncating: -Decimal(1000.1)), nil)
+        XCTAssertEqual(BigUInt(truncating: -Decimal(1000.9)), nil)
+        XCTAssertEqual(BigUInt(truncating: -Decimal(1001.5)), nil)
+        XCTAssertEqual(BigUInt(truncating: -Decimal(UInt.max) + 5), nil)
+        XCTAssertEqual(BigUInt(truncating: -(Decimal(UInt.max) + 5.5)), nil)
+    }
+
     func testInit_Buffer() {
         func test(_ b: BigUInt, _ d: Array<UInt8>, file: StaticString = #file, line: UInt = #line) {
             d.withUnsafeBytes { buffer in


### PR DESCRIPTION
I'm using this package in another package I'm working on and found myself needing to support `Decimal`.

While I was poking around, I also happened to notice that `Foundation` is very sparsely used, and therefore was easy to conditionalize for environments where Foundation might not be available (in theory, I think this might build for microcontrollers now without the Foundation features, but I have admittedly not tested it).

So this is obviously more than a small, itty bitty, incremental update, but has a few, only tangentially related features:

* Support for initializing from Decimal
    * I used a pretty naive solution, but it works
    * (requires Foundation, but...)
* Conditionally builds with Foundation features, when `#if canImport(Foundation)` is true. Otherwise, everything else is all *pure* Swift (*citation needed*)
* DRYed up the `Data` serialization and initializers, since they were right where I was working to conditionalize `Foundation`.
* DRYed up some of the FloatingPoint initializers, as a lot of the code was the same between the new `Decimal` inits and the existing ones.
* Added `CustomDebugStringConvertible` conformance, keeping it DRY with the existing Playground descriptions.

I completely understand if you don't want some, or even all of these changes and I'm happy to tweak the PR to accommodate, but I'll just have to use my own fork for my own needs then :)